### PR TITLE
Rename service annotation -> gene-to-reactions

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -99,8 +99,8 @@ http {
         server kibana.loghouse:5601;
     }
 
-    upstream annotation-staging {
-        server web.annotation-test:6500;
+    upstream gene-to-reactions-staging {
+        server web.gene-to-reactions-test:6500;
     }
 
     upstream try-cameo-bio {
@@ -418,7 +418,7 @@ http {
         }
 
         location /annotation {
-            proxy_pass http://annotation-staging;
+            proxy_pass http://gene-to-reactions-staging;
             proxy_set_header Host      $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For  $proxy_add_x_forwarded_for;


### PR DESCRIPTION
The new stack is deployed and running, so this should be ready to go. When deployed, [the old stack](https://cloud.docker.com/app/dddecaf/stack/180beb76-a245-4c14-89d5-4fe4f2d0fd1c/general) should be terminated
  