### PR TITLE
Handle CORS preflight in BiGG proxy

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -538,6 +538,20 @@ http {
         }
 
         location /bigg/ {
+            # Handle CORS preflight
+            if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Allow-Origin' '*';
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+
+                # Allow the Authorization header (which we must strip out below)
+                add_header 'Access-Control-Allow-Headers' 'Authorization';
+
+                # Return immediately - do not pass the request to bigg
+                add_header 'Content-Type' 'text/plain; charset=utf-8';
+                add_header 'Content-Length' 0;
+                return 204;
+            }
+
             proxy_pass http://bigg.ucsd.edu/api/v2/;
             proxy_set_header Authorization "";
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Adds explicit handling of `OPTIONS` requests to the BiGG proxy in nginx. This is a quick fix, a better alternative could be to set up a whole new proxy service which does the same thing (https termination + cors handling) in order to factor it out of the reverse proxy.